### PR TITLE
Added clone() to KeyframePartGroup to prevent keyframe bleedover between subsequent Queue prompt runs

### DIFF
--- a/keyframe/interface.py
+++ b/keyframe/interface.py
@@ -37,6 +37,12 @@ class KeyframePartGroup:
 
     def is_empty(self) -> bool:
         return len(self.keyframes) == 0
+    
+    def clone(self) -> 'KeyframePartGroup':
+        cloned = KeyframePartGroup()
+        for k in self.keyframes:
+            cloned.add(k)
+        return cloned
 
 
 @dataclass

--- a/keyframe/nodes.py
+++ b/keyframe/nodes.py
@@ -34,6 +34,7 @@ class KeyframePartNode:
     def load_keyframe_part(self, image, batch_index, denoise, part=None):
         if not part:
             part = KeyframePartGroup()
+        part = part.clone()
         keyframe = KeyframePart(batch_index, image, denoise)
         part.add(keyframe)
         return (part,)
@@ -75,6 +76,7 @@ class KeyframeInterpolationPartNode:
 
         if not part:
             part = KeyframePartGroup()
+        part = part.clone()
         current_group = KeyframePartGroup()
 
         steps = batch_index_to - batch_index_from


### PR DESCRIPTION
Earlier today I merged a big refactor to ComfyUI-Advanced-ControlNet, part of it was a fix to a hard-to-find bug involving how the keyframes get passed from one Keyframe-related node to another. I implemented that same fix in this PR; really, the bug only affected KeyframePartNode here, but I added it to KeyframeInterpolationPartNode as well, to prevent the issue from popping up there if the code is changed at any point.

Relevant lines here in Advanced-ControlNet code:
https://github.com/Kosinkadink/ComfyUI-Advanced-ControlNet/blob/main/control/control.py#L125
https://github.com/Kosinkadink/ComfyUI-Advanced-ControlNet/blob/main/control/latent_keyframe_nodes.py#L39